### PR TITLE
Acclamator Battleship/Praetor I Gameobjects

### DIFF
--- a/Data/Scripts/Library/eawx-mod-icw/gameobjects/ACCLAMATOR_BATTLESHIP.lua
+++ b/Data/Scripts/Library/eawx-mod-icw/gameobjects/ACCLAMATOR_BATTLESHIP.lua
@@ -1,10 +1,10 @@
 return {
 	Ship_Crew_Requirement = 600,
 	Fighters = {
-		["ELITE_FIGHTERBOMBER_DOUBLE"] = {
+		["ELITE_INTERCEPTOR"] = {
 			DEFAULT = {Initial = 1, Reserve = 2},
 		},
-		["INTERCEPTOR"] = {
+		["FIGHTER"] = {
 			DEFAULT = {Initial = 1, Reserve = 3},
 		},
 		["HEAVY_BOMBER"] = {

--- a/Data/Scripts/Library/eawx-mod-icw/gameobjects/PRAETOR_I_BATTLECRUISER.lua
+++ b/Data/Scripts/Library/eawx-mod-icw/gameobjects/PRAETOR_I_BATTLECRUISER.lua
@@ -4,7 +4,7 @@ return {
 		["FIGHTER_DOUBLE"] = {
 			DEFAULT = {Initial = 1, Reserve = 4},
 		},
-		["ELITE_FIGHTERBOMBER"] = {
+		["ELITE_INTERCEPTOR"] = {
 			DEFAULT = {Initial = 1, Reserve = 4}
 		}
 	},


### PR DESCRIPTION
Changed Gameobject loadouts for the

-Acclamator Battleship
-Praetor I

To use the Elite_Interceptor slot to vary things up a bit.