### PR TITLE
Framework Crash Fix + Shipmarket Cleanup/fixes

### DIFF
--- a/Data/Scripts/Library/DisplayNameLibrary.lua
+++ b/Data/Scripts/Library/DisplayNameLibrary.lua
@@ -43,6 +43,8 @@ return {
 	["ZSINJ_IRON_FIST_EXECUTOR"] = "Iron Fist (Zsinj)",
 	-- Submods
 	["LEGATOR_STAR_DREADNOUGHT"] = "Legator",
-	-- Shadow Realm
+	-- Project Proteus
 	["SHADOW_VENGEANCE_STAR_DREADNOUGHT"] = "Shadow Vengeance",
+	["HARRSK_MEGADOR"] = "Megador",
+	["DESANNE_DOMINION"] = "Dominion",
 }

--- a/Data/Scripts/Library/ShipMarketOptions.lua
+++ b/Data/Scripts/Library/ShipMarketOptions.lua
@@ -758,18 +758,6 @@ return {
 						order = 32,
 					},
 					
-					["STAR_GALLEON"] = {
-						locked = false,
-						gc_locked = false,
-						amount = 0,
-						chance = 50,
-						perception_modifier = nil,
-						association = nil,
-						readable_name =  "Star Galleon",
-						text_requirement = "",
-						order = 33,
-					},
-					
 					["SURVEYOR_FRIGATE"] = {
 						locked = false,
 						gc_locked = false,
@@ -779,7 +767,7 @@ return {
 						association = nil,
 						readable_name =  "Surveyor Frigate",
 						text_requirement = "",
-						order = 34,
+						order = 33,
 					},
 					
 					["ACTIVE_FRIGATE"] = {
@@ -791,7 +779,7 @@ return {
 						association = nil,
 						readable_name =  "Active Frigate",
 						text_requirement = "",
-						order = 35,
+						order = 34,
 					},
 					
 					["VIGIL"] = {
@@ -803,7 +791,7 @@ return {
 						association = nil,
 						readable_name =  "Vigil Corvette",
 						text_requirement = "",
-						order = 36,
+						order = 35,
 					},
 					
 					["RAIDER_II_CORVETTE"] = {
@@ -815,7 +803,7 @@ return {
 						association = nil,
 						readable_name =  "Raider II Corvette",
 						text_requirement = "",
-						order = 37,
+						order = 36,
 					},
 					
 					["IMPERIAL_A5_JUGGERNAUT_COMPANY"] = {
@@ -827,7 +815,7 @@ return {
 						association = nil,
 						readable_name =  "A5 Juggernaut",
 						text_requirement = "",
-						order = 38,
+						order = 37,
 					},
 					
 					["IMPERIAL_A5RX_COMPANY"] = {
@@ -839,7 +827,7 @@ return {
 						association = nil,
 						readable_name =  "A5RX Juggernaut",
 						text_requirement = "",
-						order = 39,
+						order = 38,
 					},
 					
 					["A9_FLOATING_FORTRESS_COMPANY"] = {
@@ -851,7 +839,7 @@ return {
 						association = nil,
 						readable_name =  "A9 Floating Fortress",
 						text_requirement = "",
-						order = 40,
+						order = 39,
 					},
 				
 					["C10_SIEGE_TOWER_COMPANY"] = {
@@ -863,7 +851,7 @@ return {
 						association = nil,
 						readable_name =  "C10 Siege Tower",
 						text_requirement = "",
-						order = 41,
+						order = 40,
 					},
 					
 					["IMPERIAL_AT_AP_WALKER_COMPANY"] = {
@@ -875,7 +863,7 @@ return {
 						association = nil,
 						readable_name =  "AT AP",
 						text_requirement = "",
-						order = 42,
+						order = 41,
 					},
 					
 										
@@ -888,7 +876,7 @@ return {
 						association = nil,
 						readable_name =  "MAAT",
 						text_requirement = "",
-						order = 43,
+						order = 42,
 					},
 					
 										
@@ -901,7 +889,7 @@ return {
 						association = nil,
 						readable_name =  "Imperial Modified LAAT",
 						text_requirement = "",
-						order = 44,
+						order = 43,
 					},
 					
 										
@@ -914,7 +902,7 @@ return {
 						association = nil,
 						readable_name =  "INT4 Interceptor",
 						text_requirement = "",
-						order = 45,
+						order = 44,
 					},
 					
 					["IMPERIAL_UT_AA_COMPANY"] = {
@@ -926,7 +914,7 @@ return {
 						association = nil,
 						readable_name =  "UT AA",
 						text_requirement = "",
-						order = 46,
+						order = 45,
 					},
 					
 					["SPMAT_COMPANY"] = {
@@ -936,9 +924,9 @@ return {
 						chance = 20,
 						perception_modifier = nil,
 						association = nil,
-						readable_name =  "SPAMAT",
+						readable_name =  "SPAMA-T",
 						text_requirement = "",
-						order = 47,
+						order = 46,
 					},
 					
 					["2M_REPULSOR_TANK_COMPANY"] = {
@@ -950,19 +938,7 @@ return {
 						association = nil,
 						readable_name =  "2M Repulsortank",
 						text_requirement = "",
-						order = 48,
-					},
-					
-					["IMPERIAL_TX130S_COMPANY"] = {
-						locked = false,
-						gc_locked = false,
-						amount = 0,
-						chance = 20,
-						perception_modifier = nil,
-						association = nil,
-						readable_name =  "TX130S Sabretank",
-						text_requirement = "",
-						order = 49,
+						order = 47,
 					},
 					
 					["IMPERIAL_TX130T_COMPANY"] = {
@@ -974,7 +950,7 @@ return {
 						association = nil,
 						readable_name =  "TX130T Sabretank",
 						text_requirement = "",
-						order = 50,
+						order = 48,
 					},
 					
 					["1H_TANK_COMPANY"] = {
@@ -986,7 +962,7 @@ return {
 						association = nil,
 						readable_name =  "1H Repulsortank",
 						text_requirement = "",
-						order = 51,
+						order = 49,
 					},
 					
 									
@@ -999,7 +975,7 @@ return {
 						association = nil,
 						readable_name =  "AT MP",
 						text_requirement = "",
-						order = 52,				
+						order = 50,				
 					},
 				},
 			},


### PR DESCRIPTION
-Fixed ZC Megador/Dominion Framework Crash

Shipmarket:
-Fixed SPMAT-T Typo
-Removed following redundant units to reduce potential hotbar overflow
-TX130S
-Star Galleon Tender