### PR TITLE
Random Fighter Pools

### DIFF
--- a/Data/Scripts/Library/ShipMarketOptions.lua
+++ b/Data/Scripts/Library/ShipMarketOptions.lua
@@ -25,7 +25,7 @@ return {
                     perception_modifier = nil,
                     association = nil,
                     readable_name =  "Tagge Battlecruiser",
-                    text_requirement = " [ Ulric Tagge adds 3%% ]",
+                    text_requirement = " [ Ulric Tagge adds 3% ]",
                     order = 2,
                 },
 
@@ -382,7 +382,7 @@ return {
 						perception_modifier = nil,
 						association = nil,
 						readable_name =  "Executor Star Dreadnought",
-						text_requirement = "[ Wessex Group Increases to 3%% ]",
+						text_requirement = "[ Wessex Group Increases to 3% ]",
 						order = 1,
 					},
 					

--- a/Data/Scripts/Library/eawx-plugins/government-manager/GovernmentEmpire.lua
+++ b/Data/Scripts/Library/eawx-plugins/government-manager/GovernmentEmpire.lua
@@ -714,15 +714,17 @@ function GovernmentEmpire:on_production_finished(planet, game_object_type_name)
         self:tagge_handler(planet, game_object_type_name)
     end
 
-    if game_object_type_name == "DUMMY_RECRUIT_GROUP_DELURIN" then
-        crossplot:publish("UPDATE_MARKET","DRAGON")
+    local market_updates = {
+        ["DUMMY_RECRUIT_GROUP_DELURIN"] = "DRAGON",
+        ["DUMMY_RECRUIT_GROUP_WESSEX"] = "WESSEX",
+    }
+    for group, event in pairs(market_updates) do
+        if game_object_type_name == group then
+            crossplot:publish("UPDATE_MARKET",event)
+        end
     end
 
-     if game_object_type_name == "DUMMY_RECRUIT_GROUP_WESSEX" then
-        crossplot:publish("UPDATE_MARKET","WESSEX")
-    end
-
-	if game_object_type_name == "SELLASAS_LOADOUT_SWAP1" then
+    if game_object_type_name == "SELLASAS_LOADOUT_SWAP1" then
         --locks first loadout
         UnitUtil.SetLockList("IMPERIAL_PROTEUS", {
             "Sellasas_Loadout_Swap1", "Imperial_DHC", "Neutron_Star_Mercenary", "Carrack_Cruiser", "Victory_I_Fleet_Star_Destroyer", "Victory_II_Star_Destroyer", "Imperial_I_Star_Destroyer"

--- a/Data/Scripts/Library/random-fighters/GAMBLE_BLASTBOAT.lua
+++ b/Data/Scripts/Library/random-fighters/GAMBLE_BLASTBOAT.lua
@@ -1,0 +1,5 @@
+return {
+    --["PROTEUS_GROUP_NAME"] = {
+        --list of options, Squadron Name in caps
+    --},
+}

--- a/Data/Scripts/Library/random-fighters/GAMBLE_BOMBER.lua
+++ b/Data/Scripts/Library/random-fighters/GAMBLE_BOMBER.lua
@@ -1,0 +1,5 @@
+return {
+    --["PROTEUS_GROUP_NAME"] = {
+        --list of options, Squadron Name in caps
+    --},
+}

--- a/Data/Scripts/Library/random-fighters/GAMBLE_BOMBER2.lua
+++ b/Data/Scripts/Library/random-fighters/GAMBLE_BOMBER2.lua
@@ -1,0 +1,5 @@
+return {
+    --["PROTEUS_GROUP_NAME"] = {
+        --list of options, Squadron Name in caps
+    --},
+}

--- a/Data/Scripts/Library/random-fighters/GAMBLE_ELITE_FIGHTERBOMBER.lua
+++ b/Data/Scripts/Library/random-fighters/GAMBLE_ELITE_FIGHTERBOMBER.lua
@@ -1,0 +1,5 @@
+return {
+    --["PROTEUS_GROUP_NAME"] = {
+        --list of options, Squadron Name in caps
+    --},
+}

--- a/Data/Scripts/Library/random-fighters/GAMBLE_ELITE_INTERCEPTOR.lua
+++ b/Data/Scripts/Library/random-fighters/GAMBLE_ELITE_INTERCEPTOR.lua
@@ -1,0 +1,5 @@
+return {
+    --["PROTEUS_GROUP_NAME"] = {
+        --list of options, Squadron Name in caps
+    --},
+}

--- a/Data/Scripts/Library/random-fighters/GAMBLE_FIGHTER.lua
+++ b/Data/Scripts/Library/random-fighters/GAMBLE_FIGHTER.lua
@@ -1,0 +1,5 @@
+return {
+    --["PROTEUS_GROUP_NAME"] = {
+        --list of options, Squadron Name in caps
+    --},
+}

--- a/Data/Scripts/Library/random-fighters/GAMBLE_HEAVY_BOMBER.lua
+++ b/Data/Scripts/Library/random-fighters/GAMBLE_HEAVY_BOMBER.lua
@@ -1,0 +1,5 @@
+return {
+    --["PROTEUS_GROUP_NAME"] = {
+        --list of options, Squadron Name in caps
+    --},
+}

--- a/Data/Scripts/Library/random-fighters/GAMBLE_HEAVY_FIGHTER.lua
+++ b/Data/Scripts/Library/random-fighters/GAMBLE_HEAVY_FIGHTER.lua
@@ -1,0 +1,5 @@
+return {
+    --["PROTEUS_GROUP_NAME"] = {
+        --list of options, Squadron Name in caps
+    --},
+}

--- a/Data/Scripts/Library/random-fighters/GAMBLE_INTERCEPTOR.lua
+++ b/Data/Scripts/Library/random-fighters/GAMBLE_INTERCEPTOR.lua
@@ -1,0 +1,5 @@
+return {
+    --["PROTEUS_GROUP_NAME"] = {
+        --list of options, Squadron Name in caps
+    --},
+}

--- a/Data/Scripts/Library/random-fighters/GAMBLE_LIGHT_FIGHTER.lua
+++ b/Data/Scripts/Library/random-fighters/GAMBLE_LIGHT_FIGHTER.lua
@@ -1,0 +1,5 @@
+return {
+    --["PROTEUS_GROUP_NAME"] = {
+        --list of options, Squadron Name in caps
+    --},
+}

--- a/Data/Scripts/Library/random-fighters/GAMBLE_LIGHT_FIGHTERBOMBER.lua
+++ b/Data/Scripts/Library/random-fighters/GAMBLE_LIGHT_FIGHTERBOMBER.lua
@@ -1,0 +1,5 @@
+return {
+    --["PROTEUS_GROUP_NAME"] = {
+        --list of options, Squadron Name in caps
+    --},
+}

--- a/Data/Scripts/Library/standard-fighters/Blastboat.lua
+++ b/Data/Scripts/Library/standard-fighters/Blastboat.lua
@@ -103,6 +103,15 @@ return {
 				local group_name = GlobalValue.Get("PROTEUS_GROUP_NAME")
 				if proteustypes[group_name] then
 					fighter = proteustypes[group_name][1]
+					if string.find(fighter, "GAMBLE_") then
+						local random_list = require("random-fighters/GAMBLE_BLASTBOAT")
+						local select = GameRandom.Free_Random(1, table.getn(random_list[group_name]))
+						for pos, obj in pairs(random_list[group_name]) do
+							if pos == select then
+								fighter = obj
+							end
+						end
+					end
 					if proteustypes[group_name][2] ~= false then
 						if Check_Flags(flags, "PROTEUS_OVERRIDE") then
 							fighter = proteustypes[group_name][2]

--- a/Data/Scripts/Library/standard-fighters/Bomber.lua
+++ b/Data/Scripts/Library/standard-fighters/Bomber.lua
@@ -114,6 +114,15 @@ return {
 				local group_name = GlobalValue.Get("PROTEUS_GROUP_NAME")
 				if proteustypes[group_name] then
 					fighter = proteustypes[group_name][1]
+					if string.find(fighter, "GAMBLE_") then
+						local random_list = require("random-fighters/GAMBLE_BOMBER")
+						local select = GameRandom.Free_Random(1, table.getn(random_list[group_name]))
+						for pos, obj in pairs(random_list[group_name]) do
+							if pos == select then
+								fighter = obj
+							end
+						end
+					end
 					if proteustypes[group_name][2] ~= false then
 						if Check_Flags(flags, "PROTEUS_OVERRIDE") then
 							fighter = proteustypes[group_name][2]

--- a/Data/Scripts/Library/standard-fighters/Bomber2.lua
+++ b/Data/Scripts/Library/standard-fighters/Bomber2.lua
@@ -121,6 +121,15 @@ return {
             local group_name = GlobalValue.Get("PROTEUS_GROUP_NAME")
             if proteustypes[group_name] then
                 fighter = proteustypes[group_name][1]
+				if string.find(fighter, "GAMBLE_") then
+						local random_list = require("random-fighters/GAMBLE_BOMBER2")
+						local select = GameRandom.Free_Random(1, table.getn(random_list[group_name]))
+						for pos, obj in pairs(random_list[group_name]) do
+							if pos == select then
+								fighter = obj
+							end
+						end
+					end
                 if proteustypes[group_name][2] ~= false then
                     if Check_Flags(flags, "PROTEUS_OVERRIDE") then
                         fighter = proteustypes[group_name][2]

--- a/Data/Scripts/Library/standard-fighters/ELITE_FIGHTERBOMBER.lua
+++ b/Data/Scripts/Library/standard-fighters/ELITE_FIGHTERBOMBER.lua
@@ -85,6 +85,15 @@ return {
             local group_name = GlobalValue.Get("PROTEUS_GROUP_NAME")
             if proteustypes[group_name] then
                 fighter = proteustypes[group_name][1]
+				if string.find(fighter, "GAMBLE_") then
+						local random_list = require("random-fighters/GAMBLE_ELITE_FIGHTERBOMBER")
+						local select = GameRandom.Free_Random(1, table.getn(random_list[group_name]))
+						for pos, obj in pairs(random_list[group_name]) do
+							if pos == select then
+								fighter = obj
+							end
+						end
+					end
                 if proteustypes[group_name][2] ~= false then
                     if Check_Flags(flags, "PROTEUS_OVERRIDE") then
                         fighter = proteustypes[group_name][2]

--- a/Data/Scripts/Library/standard-fighters/ELITE_INTERCEPTOR.lua
+++ b/Data/Scripts/Library/standard-fighters/ELITE_INTERCEPTOR.lua
@@ -112,6 +112,15 @@ return {
 				local group_name = GlobalValue.Get("PROTEUS_GROUP_NAME")
 				if proteustypes[group_name] then
 					fighter = proteustypes[group_name][1]
+					if string.find(fighter, "GAMBLE_") then
+						local random_list = require("random-fighters/GAMBLE_ELITE_INTERCEPTOR")
+						local select = GameRandom.Free_Random(1, table.getn(random_list[group_name]))
+						for pos, obj in pairs(random_list[group_name]) do
+							if pos == select then
+								fighter = obj
+							end
+						end
+					end
 					if proteustypes[group_name][2] ~= false then
 						if Check_Flags(flags, "PROTEUS_OVERRIDE") then
 							fighter = proteustypes[group_name][2]

--- a/Data/Scripts/Library/standard-fighters/Fighter.lua
+++ b/Data/Scripts/Library/standard-fighters/Fighter.lua
@@ -126,6 +126,15 @@ return {
 				local group_name = GlobalValue.Get("PROTEUS_GROUP_NAME")
 				if proteustypes[group_name] then
 					fighter = proteustypes[group_name][1]
+					if string.find(fighter, "GAMBLE_") then
+						local random_list = require("random-fighters/GAMBLE_FIGHTER")
+						local select = GameRandom.Free_Random(1, table.getn(random_list[group_name]))
+						for pos, obj in pairs(random_list[group_name]) do
+							if pos == select then
+								fighter = obj
+							end
+						end
+					end
 					if proteustypes[group_name][2] ~= false then
 						if Check_Flags(flags, "PROTEUS_OVERRIDE") then
 							fighter = proteustypes[group_name][2]

--- a/Data/Scripts/Library/standard-fighters/HEAVY_BOMBER.lua
+++ b/Data/Scripts/Library/standard-fighters/HEAVY_BOMBER.lua
@@ -109,6 +109,15 @@ return {
 				local group_name = GlobalValue.Get("PROTEUS_GROUP_NAME")
 				if proteustypes[group_name] then
 					fighter = proteustypes[group_name][1]
+					if string.find(fighter, "GAMBLE_") then
+						local random_list = require("random-fighters/GAMBLE_HEAVY_BOMBER")
+						local select = GameRandom.Free_Random(1, table.getn(random_list[group_name]))
+						for pos, obj in pairs(random_list[group_name]) do
+							if pos == select then
+								fighter = obj
+							end
+						end
+					end
 					if proteustypes[group_name][2] ~= false then
 						if Check_Flags(flags, "PROTEUS_OVERRIDE") then
 							fighter = proteustypes[group_name][2]

--- a/Data/Scripts/Library/standard-fighters/HEAVY_FIGHTER.lua
+++ b/Data/Scripts/Library/standard-fighters/HEAVY_FIGHTER.lua
@@ -110,6 +110,15 @@ return {
             local group_name = GlobalValue.Get("PROTEUS_GROUP_NAME")
             if proteustypes[group_name] then
                 fighter = proteustypes[group_name][1]
+				if string.find(fighter, "GAMBLE_") then
+					local random_list = require("random-fighters/GAMBLE_HEAVY_FIGHTER")
+					local select = GameRandom.Free_Random(1, table.getn(random_list[group_name]))
+					for pos, obj in pairs(random_list[group_name]) do
+						if pos == select then
+							fighter = obj
+						end
+					end
+				end
                 if proteustypes[group_name][2] ~= false then
                     if Check_Flags(flags, "PROTEUS_OVERRIDE") then
                         fighter = proteustypes[group_name][2]

--- a/Data/Scripts/Library/standard-fighters/Interceptor.lua
+++ b/Data/Scripts/Library/standard-fighters/Interceptor.lua
@@ -131,6 +131,15 @@ return {
 				local group_name = GlobalValue.Get("PROTEUS_GROUP_NAME")
 				if proteustypes[group_name] then
 					fighter = proteustypes[group_name][1]
+					if string.find(fighter, "GAMBLE_") then
+						local random_list = require("random-fighters/GAMBLE_INTERCEPTOR")
+						local select = GameRandom.Free_Random(1, table.getn(random_list[group_name]))
+						for pos, obj in pairs(random_list[group_name]) do
+							if pos == select then
+								fighter = obj
+							end
+						end
+					end
 					if proteustypes[group_name][2] ~= false then
 						if Check_Flags(flags, "PROTEUS_OVERRIDE") then
 							fighter = proteustypes[group_name][2]

--- a/Data/Scripts/Library/standard-fighters/LIGHT_FIGHTER.lua
+++ b/Data/Scripts/Library/standard-fighters/LIGHT_FIGHTER.lua
@@ -96,6 +96,15 @@ return {
 					local group_name = GlobalValue.Get("PROTEUS_GROUP_NAME")
 					if proteustypes[group_name] then
 						fighter = proteustypes[group_name][1]
+						if string.find(fighter, "GAMBLE_") then
+						local random_list = require("random-fighters/GAMBLE_LIGHT_FIGHTER")
+						local select = GameRandom.Free_Random(1, table.getn(random_list[group_name]))
+						for pos, obj in pairs(random_list[group_name]) do
+							if pos == select then
+								fighter = obj
+							end
+						end
+					end
 						if proteustypes[group_name][2] ~= false then
 							if Check_Flags(flags, "PROTEUS_OVERRIDE") then
 								fighter = proteustypes[group_name][2]

--- a/Data/Scripts/Library/standard-fighters/LIGHT_FIGHTERBOMBER.lua
+++ b/Data/Scripts/Library/standard-fighters/LIGHT_FIGHTERBOMBER.lua
@@ -94,6 +94,15 @@ return {
 				local group_name = GlobalValue.Get("PROTEUS_GROUP_NAME")
 				if proteustypes[group_name] then
 					fighter = proteustypes[group_name][1]
+					if string.find(fighter, "GAMBLE_") then
+						local random_list = require("random-fighters/GAMBLE_LIGHT_FIGHTERBOMBER")
+						local select = GameRandom.Free_Random(1, table.getn(random_list[group_name]))
+						for pos, obj in pairs(random_list[group_name]) do
+							if pos == select then
+								fighter = obj
+							end
+						end
+					end
 					if proteustypes[group_name][2] ~= false then
 						if Check_Flags(flags, "PROTEUS_OVERRIDE") then
 							fighter = proteustypes[group_name][2]


### PR DESCRIPTION
-Fighters/Bombers can now be drawn from a random list -does not include Era specific spawns
-works without having to assign new types within the GameObjects - defined in the standard-fighters -separate Libraries per Type, group specific but not limited to one